### PR TITLE
Email service and reset password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ gradle-app.setting
 # OS-specific files
 .DS_Store
 Thumbs.db
+
+# Credentials
+/qualitag/src/main/resources/credentials_test.json
+/tokens/StoredCredential

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,4 @@ gradle-app.setting
 Thumbs.db
 
 # Credentials
-/qualitag/src/main/resources/credentials_test.json
-/tokens/StoredCredential
+/qualitag/src/main/resources/credentials/**

--- a/qualitag/build.gradle
+++ b/qualitag/build.gradle
@@ -84,6 +84,9 @@ dependencies {
     implementation 'com.google.api-client:google-api-client:2.7.0'
     implementation 'com.google.oauth-client:google-oauth-client-jetty:1.36.0'
     implementation 'com.google.apis:google-api-services-gmail:v1-rev20240520-2.0.0'
+
+    // Jakarta Mail
+    implementation 'com.sun.mail:jakarta.mail:2.0.1'
 }
 
 // Checkstyle configuration for Google Java Style

--- a/qualitag/build.gradle
+++ b/qualitag/build.gradle
@@ -79,6 +79,11 @@ dependencies {
 
     // Thymeleaf
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+    // Gmail API
+    implementation 'com.google.api-client:google-api-client:2.7.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.36.0'
+    implementation 'com.google.apis:google-api-services-gmail:v1-rev20240520-2.0.0'
 }
 
 // Checkstyle configuration for Google Java Style

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/dto/user/ForgotPasswordDto.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/dto/user/ForgotPasswordDto.java
@@ -1,0 +1,9 @@
+package it.unisannio.studenti.qualitag.dto.user;
+
+/**
+ * The ForgotPasswordDto class is a DTO that represents the email where to send the
+ * link used for password reset.
+ */
+public record ForgotPasswordDto(String email) {
+
+}

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/model/User.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/model/User.java
@@ -1,5 +1,6 @@
 package it.unisannio.studenti.qualitag.model;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -45,6 +46,9 @@ public class User {
   @Field(name = "surname")
   private String surname;
 
+  @Field(name = "resetTokenExpiration")
+  private LocalDateTime resetTokenExpiration;
+
   @Field(name = "projectIds")
   private List<String> projectIds;
 
@@ -63,6 +67,8 @@ public class User {
    * Constructs a new User with no parameters.
    */
   public User() {
+    this.resetTokenExpiration = null;
+
     this.projectIds = new ArrayList<>();
     this.teamIds = new ArrayList<>();
     this.tagIds = new ArrayList<>();
@@ -84,6 +90,8 @@ public class User {
     this.passwordHash = passwordHash;
     this.name = name;
     this.surname = surname;
+
+    this.resetTokenExpiration = null;
 
     this.projectIds = new ArrayList<>();
     this.teamIds = new ArrayList<>();

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/repository/UserRepository.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/repository/UserRepository.java
@@ -42,9 +42,17 @@ public interface UserRepository extends MongoRepository<User, String> {
   User findByUsername(String username);
 
   /**
-   * Deletes a user by its id.
+   * Finds a user by its email.
    *
-   * @param username The id of the user to delete.
+   * @param email The email of the user to find.
+   * @return User with the given email.
+   */
+  User findByEmail(String email);
+
+  /**
+   * Deletes a user by its username.
+   *
+   * @param username The username of the user to delete.
    */
   void deleteByUsername(String username);
 }

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/security/controller/AuthenticationController.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/security/controller/AuthenticationController.java
@@ -28,7 +28,8 @@ public class AuthenticationController {
    * @return The response entity.
    */
   @PostMapping("/register")
-  public ResponseEntity<?> registerUser(@RequestBody UserRegistrationDto userRegistrationDto) {
+  public ResponseEntity<?> registerUser(@RequestBody UserRegistrationDto userRegistrationDto)
+      throws Exception {
     return authenticationService.register(userRegistrationDto);
   }
 

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/security/controller/AuthenticationController.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/security/controller/AuthenticationController.java
@@ -1,5 +1,6 @@
 package it.unisannio.studenti.qualitag.security.controller;
 
+import it.unisannio.studenti.qualitag.dto.user.ForgotPasswordDto;
 import it.unisannio.studenti.qualitag.dto.user.PasswordUpdateDto;
 import it.unisannio.studenti.qualitag.dto.user.UserLoginDto;
 import it.unisannio.studenti.qualitag.dto.user.UserRegistrationDto;
@@ -47,7 +48,7 @@ public class AuthenticationController {
   }
 
   @PostMapping("/forgot-password")
-  public ResponseEntity<?> forgotPassword(@RequestParam String email) throws Exception {
+  public ResponseEntity<?> forgotPassword(@RequestBody ForgotPasswordDto email) throws Exception {
     return authenticationService.sendPasswordResetEmail(email);
   }
 

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/security/controller/AuthenticationController.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/security/controller/AuthenticationController.java
@@ -47,11 +47,24 @@ public class AuthenticationController {
     return authenticationService.login(userLoginDto);
   }
 
+  /**
+   * Sends a password reset email.
+   *
+   * @param email The email.
+   * @return The response entity.
+   */
   @PostMapping("/forgot-password")
   public ResponseEntity<?> forgotPassword(@RequestBody ForgotPasswordDto email) throws Exception {
     return authenticationService.sendPasswordResetEmail(email);
   }
 
+  /**
+   * Resets the password.
+   *
+   * @param token The token.
+   * @param passwordUpdateDto The password update DTO.
+   * @return The response entity.
+   */
   @PostMapping("/reset-password")
   public ResponseEntity<?> resetPassword(@RequestParam String token, @RequestBody
       PasswordUpdateDto passwordUpdateDto) {

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/security/controller/AuthenticationController.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/security/controller/AuthenticationController.java
@@ -1,5 +1,6 @@
 package it.unisannio.studenti.qualitag.security.controller;
 
+import it.unisannio.studenti.qualitag.dto.user.PasswordUpdateDto;
 import it.unisannio.studenti.qualitag.dto.user.UserLoginDto;
 import it.unisannio.studenti.qualitag.dto.user.UserRegistrationDto;
 import it.unisannio.studenti.qualitag.security.service.AuthenticationService;
@@ -8,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -42,5 +44,16 @@ public class AuthenticationController {
   @PostMapping("/login")
   public ResponseEntity<?> loginUser(@RequestBody UserLoginDto userLoginDto) {
     return authenticationService.login(userLoginDto);
+  }
+
+  @PostMapping("/forgot-password")
+  public ResponseEntity<?> forgotPassword(@RequestParam String email) throws Exception {
+    return authenticationService.sendPasswordResetEmail(email);
+  }
+
+  @PostMapping("/reset-password")
+  public ResponseEntity<?> resetPassword(@RequestParam String token, @RequestBody
+      PasswordUpdateDto passwordUpdateDto) {
+    return authenticationService.resetPassword(token, passwordUpdateDto);
   }
 }

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/security/filter/JwtAuthenticationFilter.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/security/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package it.unisannio.studenti.qualitag.security.filter;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import it.unisannio.studenti.qualitag.security.service.CustomUserDetailService;
 import it.unisannio.studenti.qualitag.security.service.JwtService;
 import jakarta.servlet.FilterChain;
@@ -45,7 +46,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     jwt = authHeader.substring(7);
     log.debug("JWT - {}", jwt);
-    userIdentifier = jwtService.extractUserName(jwt);
+
+    try {
+      userIdentifier = jwtService.extractUserName(jwt);
+    } catch (ExpiredJwtException e) {
+      log.error("JWT expired - {}", e.getMessage());
+      filterChain.doFilter(request, response);
+      return;
+    }
+
 
     if (userIdentifier != null && SecurityContextHolder.getContext().getAuthentication() == null) {
       UserDetails userDetails = customUserDetailService.loadUserByUsername(userIdentifier);

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/security/service/AuthenticationService.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/security/service/AuthenticationService.java
@@ -6,6 +6,7 @@ import it.unisannio.studenti.qualitag.mapper.UserMapper;
 import it.unisannio.studenti.qualitag.model.User;
 import it.unisannio.studenti.qualitag.repository.UserRepository;
 import it.unisannio.studenti.qualitag.security.model.CustomUserDetails;
+import it.unisannio.studenti.qualitag.service.GmailService;
 import it.unisannio.studenti.qualitag.service.UserService;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
@@ -88,7 +89,7 @@ public class AuthenticationService {
    * @param request The user registration request.
    * @return The response entity.
    */
-  public ResponseEntity<?> register(UserRegistrationDto request) {
+  public ResponseEntity<?> register(UserRegistrationDto request) throws Exception {
     Map<String, Object> response = new HashMap<>();
 
     // DTO validation
@@ -126,6 +127,11 @@ public class AuthenticationService {
       response.put("msg", "Email already taken.");
       return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
+
+    // Send email
+    new GmailService().sendMail("QualiTag Registration",
+        request.email(),
+        "Thank you for registering to QualiTag!");
 
     // Map the new user from the request
     User user = userMapper.toEntity(request);

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/security/service/AuthenticationService.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/security/service/AuthenticationService.java
@@ -1,5 +1,6 @@
 package it.unisannio.studenti.qualitag.security.service;
 
+import it.unisannio.studenti.qualitag.dto.user.ForgotPasswordDto;
 import it.unisannio.studenti.qualitag.dto.user.PasswordUpdateDto;
 import it.unisannio.studenti.qualitag.dto.user.UserLoginDto;
 import it.unisannio.studenti.qualitag.dto.user.UserRegistrationDto;
@@ -197,13 +198,13 @@ public class AuthenticationService {
   /**
    * Sends a password reset email to the user.
    *
-   * @param email The email of the user.
+   * @param dto The DTO containing email of the user.
    * @return The response entity.
    */
-  public ResponseEntity<?> sendPasswordResetEmail(String email) throws Exception {
+  public ResponseEntity<?> sendPasswordResetEmail(ForgotPasswordDto dto) throws Exception {
     Map<String, Object> response = new HashMap<>();
 
-    User user = userRepository.findByEmail(email);
+    User user = userRepository.findByEmail(dto.email());
     if (user == null) {
       response.put("msg", "No user found with the given email.");
       return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
@@ -219,7 +220,7 @@ public class AuthenticationService {
     // Send email with reset link
     String resetLink = "http://localhost:8080/reset-password?token=" + resetToken;
     new GmailService().sendMail("QualiTag Password Reset",
-        email,
+        dto.email(),
         "Click the following link to reset your password: " + resetLink);
 
     response.put("msg", "Password reset email sent successfully.");

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/security/service/JwtService.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/security/service/JwtService.java
@@ -40,7 +40,7 @@ public class JwtService {
    * @param token the token
    * @return the username
    */
-  public String extractUserName(String token) {
+  public String extractUserName(String token) throws ExpiredJwtException {
     return extractClaim(token, Claims::getSubject);
   }
 
@@ -124,7 +124,7 @@ public class JwtService {
     return extractExpiration(token).before(new Date());
   }
 
-  private Date extractExpiration(String token) {
+  private Date extractExpiration(String token) throws ExpiredJwtException {
     return extractClaim(token, Claims::getExpiration);
   }
 

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/security/service/JwtService.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/security/service/JwtService.java
@@ -1,6 +1,7 @@
 package it.unisannio.studenti.qualitag.security.service;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
@@ -113,7 +114,8 @@ public class JwtService {
    * @param <T>             the type of the claim
    * @return the claim
    */
-  private <T> T extractClaim(String token, Function<Claims, T> claimsResolvers) {
+  private <T> T extractClaim(String token, Function<Claims, T> claimsResolvers)
+      throws ExpiredJwtException {
     final Claims claims = extractAllClaims(token);
     return claimsResolvers.apply(claims);
   }

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/GmailService.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/GmailService.java
@@ -112,7 +112,8 @@ public class GmailService {
 
     try {
       // Send the e-mail using the Gmail API
-      service.users().messages().send(FROM_EMAIL, msg).execute();
+      msg = service.users().messages().send(FROM_EMAIL, msg).execute();
+      System.out.println("Message sent: " + msg.toPrettyString());
     } catch (GoogleJsonResponseException e) {
       GoogleJsonError error = e.getDetails();
       if (error.getCode() == 403) {

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/GmailService.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/GmailService.java
@@ -103,9 +103,7 @@ public class GmailService {
     msg.setRaw(encodedEmail);
 
     try {
-      msg = service.users().messages().send(FROM_EMAIL, msg).execute();
-      System.out.println("Message id: " + msg.getId());
-      System.out.println(msg.toPrettyString());
+      service.users().messages().send(FROM_EMAIL, msg).execute();
     } catch (GoogleJsonResponseException e) {
       GoogleJsonError error = e.getDetails();
       if (error.getCode() == 403) {

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/GmailService.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/GmailService.java
@@ -26,12 +26,10 @@ import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.Set;
 import org.apache.commons.codec.binary.Base64;
-import org.springframework.stereotype.Service;
 
 /**
  * This class is used to send e-mails using the Gmail API.
  */
-@Service
 public class GmailService {
 
   private static final String TEST_EMAIL = "qualitag.project@gmail.com";
@@ -75,7 +73,7 @@ public class GmailService {
     GoogleAuthorizationCodeFlow flow = new GoogleAuthorizationCodeFlow.Builder(
         httpTransport, jsonFactory, clientSecrets, Set.of(GMAIL_SEND))
         .setDataStoreFactory(new FileDataStoreFactory(
-            Paths.get("qualitag/src/main/resources/credentials/tokens").toFile()))
+            Paths.get("/src/main/resources/credentials/tokens").toFile()))
         .setAccessType("offline")
         .build();
 

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/GmailService.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/GmailService.java
@@ -1,5 +1,8 @@
 package it.unisannio.studenti.qualitag.service;
 
+import static com.google.api.services.gmail.GmailScopes.GMAIL_SEND;
+import static jakarta.mail.Message.RecipientType.TO;
+
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;
 import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver;
@@ -13,8 +16,6 @@ import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.gmail.Gmail;
 import com.google.api.services.gmail.model.Message;
-import org.apache.commons.codec.binary.Base64;
-
 import jakarta.mail.Session;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
@@ -24,16 +25,24 @@ import java.io.InputStreamReader;
 import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.Set;
+import org.apache.commons.codec.binary.Base64;
+import org.springframework.stereotype.Service;
 
-import static com.google.api.services.gmail.GmailScopes.GMAIL_SEND;
-import static jakarta.mail.Message.RecipientType.TO;
-
+/**
+ * This class is used to send e-mails using the Gmail API.
+ */
+@Service
 public class GmailService {
 
   private static final String TEST_EMAIL = "qualitag.project@gmail.com";
   private static final String FROM_EMAIL = "qualitag.project@gmail.com";
   private final Gmail service;
 
+  /**
+   * Constructor that initializes the Gmail service.
+   *
+   * @throws Exception if an error occurs while initializing the service.
+   */
   public GmailService() throws Exception {
     NetHttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     GsonFactory jsonFactory = GsonFactory.getDefaultInstance();
@@ -43,6 +52,14 @@ public class GmailService {
         .build();
   }
 
+  /**
+   * Creates a new Gmail service instance.
+   *
+   * @param httpTransport the HTTP transport.
+   * @param jsonFactory the JSON factory.
+   * @return the Gmail service instance.
+   * @throws IOException if an error occurs while loading the credentials.
+   */
   private static Credential getCredentials(final NetHttpTransport httpTransport,
       GsonFactory jsonFactory)
       throws IOException {
@@ -59,6 +76,14 @@ public class GmailService {
     return new AuthorizationCodeInstalledApp(flow, receiver).authorize("user");
   }
 
+  /**
+   * Sends an e-mail message.
+   *
+   * @param subject the e-mail subject.
+   * @param to the recipient e-mail address.
+   * @param message the e-mail message.
+   * @throws Exception if an error occurs while sending the e-mail.
+   */
   public void sendMail(String subject, String to, String message) throws Exception {
     Properties props = new Properties();
     Session session = Session.getDefaultInstance(props, null);
@@ -89,6 +114,12 @@ public class GmailService {
     }
   }
 
+  /**
+   * Main method used to test the Gmail service.
+   *
+   * @param args the command-line arguments.
+   * @throws Exception if an error occurs while sending the e-mail.
+   */
   public static void main(String[] args) throws Exception {
     new GmailService().sendMail("Test e-mail",
         TEST_EMAIL,

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/GmailService.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/GmailService.java
@@ -48,7 +48,7 @@ public class GmailService {
     GsonFactory jsonFactory = GsonFactory.getDefaultInstance();
     service = new Gmail.Builder(httpTransport, jsonFactory,
         getCredentials(httpTransport, jsonFactory))
-        .setApplicationName("Test Mailer")
+        .setApplicationName("QualiTag Project")
         .build();
   }
 
@@ -56,7 +56,7 @@ public class GmailService {
    * Creates a new Gmail service instance.
    *
    * @param httpTransport the HTTP transport.
-   * @param jsonFactory the JSON factory.
+   * @param jsonFactory   the JSON factory.
    * @return the Gmail service instance.
    * @throws IOException if an error occurs while loading the credentials.
    */
@@ -64,11 +64,13 @@ public class GmailService {
       GsonFactory jsonFactory)
       throws IOException {
     GoogleClientSecrets clientSecrets = GoogleClientSecrets.load(jsonFactory,
-        new InputStreamReader(GmailService.class.getResourceAsStream("/credentials_test.json")));
+        new InputStreamReader(GmailService.class.getResourceAsStream(
+            "/credentials/credentials_email_service.json")));
 
     GoogleAuthorizationCodeFlow flow = new GoogleAuthorizationCodeFlow.Builder(
         httpTransport, jsonFactory, clientSecrets, Set.of(GMAIL_SEND))
-        .setDataStoreFactory(new FileDataStoreFactory(Paths.get("tokens").toFile()))
+        .setDataStoreFactory(new FileDataStoreFactory(
+            Paths.get("qualitag/src/main/resources/credentials/tokens").toFile()))
         .setAccessType("offline")
         .build();
 
@@ -80,7 +82,7 @@ public class GmailService {
    * Sends an e-mail message.
    *
    * @param subject the e-mail subject.
-   * @param to the recipient e-mail address.
+   * @param to      the recipient e-mail address.
    * @param message the e-mail message.
    * @throws Exception if an error occurs while sending the e-mail.
    */
@@ -88,7 +90,7 @@ public class GmailService {
     Properties props = new Properties();
     Session session = Session.getDefaultInstance(props, null);
     MimeMessage email = new MimeMessage(session);
-    email.setFrom(new InternetAddress(FROM_EMAIL));
+    email.setFrom("QualiTag Project <" + FROM_EMAIL + ">");
     email.addRecipient(TO, new InternetAddress(to));
     email.setSubject(subject);
     email.setText(message);
@@ -101,7 +103,7 @@ public class GmailService {
     msg.setRaw(encodedEmail);
 
     try {
-      msg = service.users().messages().send("me", msg).execute();
+      msg = service.users().messages().send(FROM_EMAIL, msg).execute();
       System.out.println("Message id: " + msg.getId());
       System.out.println(msg.toPrettyString());
     } catch (GoogleJsonResponseException e) {
@@ -121,8 +123,8 @@ public class GmailService {
    * @throws Exception if an error occurs while sending the e-mail.
    */
   public static void main(String[] args) throws Exception {
-    new GmailService().sendMail("Test e-mail",
+    new GmailService().sendMail(" Test e-mail",
         TEST_EMAIL,
-        "This is a test e-mail from the Test Mailer application.");
+        "This is a test e-mail.");
   }
 }

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/GmailService.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/GmailService.java
@@ -30,7 +30,8 @@ import static jakarta.mail.Message.RecipientType.TO;
 
 public class GmailService {
 
-  private static final String TEST_EMAIL = "mattia.marino01@gmail.com";
+  private static final String TEST_EMAIL = "qualitag.project@gmail.com";
+  private static final String FROM_EMAIL = "qualitag.project@gmail.com";
   private final Gmail service;
 
   public GmailService() throws Exception {
@@ -58,12 +59,12 @@ public class GmailService {
     return new AuthorizationCodeInstalledApp(flow, receiver).authorize("user");
   }
 
-  public void sendMailTest(String subject, String message) throws Exception {
+  public void sendMail(String subject, String to, String message) throws Exception {
     Properties props = new Properties();
     Session session = Session.getDefaultInstance(props, null);
     MimeMessage email = new MimeMessage(session);
-    email.setFrom(new InternetAddress(TEST_EMAIL));
-    email.addRecipient(TO, new InternetAddress(TEST_EMAIL));
+    email.setFrom(new InternetAddress(FROM_EMAIL));
+    email.addRecipient(TO, new InternetAddress(to));
     email.setSubject(subject);
     email.setText(message);
 
@@ -89,9 +90,8 @@ public class GmailService {
   }
 
   public static void main(String[] args) throws Exception {
-    new GmailService().sendMailTest("Test e-mail",
-        """
-            This is a test e-mail.
-            """);
+    new GmailService().sendMail("Test e-mail",
+        TEST_EMAIL,
+        "This is a test e-mail from the Test Mailer application.");
   }
 }

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/GmailService.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/GmailService.java
@@ -73,7 +73,7 @@ public class GmailService {
     GoogleAuthorizationCodeFlow flow = new GoogleAuthorizationCodeFlow.Builder(
         httpTransport, jsonFactory, clientSecrets, Set.of(GMAIL_SEND))
         .setDataStoreFactory(new FileDataStoreFactory(
-            Paths.get("/src/main/resources/credentials/tokens").toFile()))
+            Paths.get("qualitag/src/main/resources/credentials/tokens").toFile()))
         .setAccessType("offline")
         .build();
 

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/GmailService.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/GmailService.java
@@ -1,0 +1,97 @@
+package it.unisannio.studenti.qualitag.service;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;
+import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver;
+import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
+import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.util.store.FileDataStoreFactory;
+import com.google.api.services.gmail.Gmail;
+import com.google.api.services.gmail.model.Message;
+import org.apache.commons.codec.binary.Base64;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Paths;
+import java.util.Properties;
+import java.util.Set;
+
+import static com.google.api.services.gmail.GmailScopes.GMAIL_SEND;
+import static jakarta.mail.Message.RecipientType.TO;
+
+public class GmailService {
+
+  private static final String TEST_EMAIL = "mattia.marino01@gmail.com";
+  private final Gmail service;
+
+  public GmailService() throws Exception {
+    NetHttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+    GsonFactory jsonFactory = GsonFactory.getDefaultInstance();
+    service = new Gmail.Builder(httpTransport, jsonFactory,
+        getCredentials(httpTransport, jsonFactory))
+        .setApplicationName("Test Mailer")
+        .build();
+  }
+
+  private static Credential getCredentials(final NetHttpTransport httpTransport,
+      GsonFactory jsonFactory)
+      throws IOException {
+    GoogleClientSecrets clientSecrets = GoogleClientSecrets.load(jsonFactory,
+        new InputStreamReader(GmailService.class.getResourceAsStream("/credentials_test.json")));
+
+    GoogleAuthorizationCodeFlow flow = new GoogleAuthorizationCodeFlow.Builder(
+        httpTransport, jsonFactory, clientSecrets, Set.of(GMAIL_SEND))
+        .setDataStoreFactory(new FileDataStoreFactory(Paths.get("tokens").toFile()))
+        .setAccessType("offline")
+        .build();
+
+    LocalServerReceiver receiver = new LocalServerReceiver.Builder().setPort(8888).build();
+    return new AuthorizationCodeInstalledApp(flow, receiver).authorize("user");
+  }
+
+  public void sendMailTest(String subject, String message) throws Exception {
+    Properties props = new Properties();
+    Session session = Session.getDefaultInstance(props, null);
+    MimeMessage email = new MimeMessage(session);
+    email.setFrom(new InternetAddress(TEST_EMAIL));
+    email.addRecipient(TO, new InternetAddress(TEST_EMAIL));
+    email.setSubject(subject);
+    email.setText(message);
+
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    email.writeTo(buffer);
+    byte[] rawMessageBytes = buffer.toByteArray();
+    String encodedEmail = Base64.encodeBase64URLSafeString(rawMessageBytes);
+    Message msg = new Message();
+    msg.setRaw(encodedEmail);
+
+    try {
+      msg = service.users().messages().send("me", msg).execute();
+      System.out.println("Message id: " + msg.getId());
+      System.out.println(msg.toPrettyString());
+    } catch (GoogleJsonResponseException e) {
+      GoogleJsonError error = e.getDetails();
+      if (error.getCode() == 403) {
+        System.err.println("Unable to send message: " + e.getDetails());
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    new GmailService().sendMailTest("Test e-mail",
+        """
+            This is a test e-mail.
+            """);
+  }
+}

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/UserService.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/UserService.java
@@ -4,7 +4,6 @@ import it.unisannio.studenti.qualitag.dto.user.PasswordUpdateDto;
 import it.unisannio.studenti.qualitag.dto.user.UserInfoDisplayDto;
 import it.unisannio.studenti.qualitag.dto.user.UserModifyDto;
 import it.unisannio.studenti.qualitag.mapper.UserMapper;
-import it.unisannio.studenti.qualitag.model.Tag;
 import it.unisannio.studenti.qualitag.model.User;
 import it.unisannio.studenti.qualitag.repository.UserRepository;
 import it.unisannio.studenti.qualitag.security.model.CustomUserDetails;
@@ -15,7 +14,6 @@ import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -61,16 +59,19 @@ public class UserService {
     // DTO validation
     Set<ConstraintViolation<PasswordUpdateDto>> violations = validator.validate(
         passwordUpdateDto);
-    if (!violations.isEmpty())
+    if (!violations.isEmpty()) {
       return "All fields must be filled.";
+    }
 
     // Password validation
-    if (UserService.isNotValidPassword(passwordUpdateDto.newPassword()))
+    if (UserService.isNotValidPassword(passwordUpdateDto.newPassword())) {
       return "Invalid password.";
+    }
 
     // Check if the two passwords in the DTO are the same
-    if (!passwordUpdateDto.newPassword().equals(passwordUpdateDto.confirmPassword()))
+    if (!passwordUpdateDto.newPassword().equals(passwordUpdateDto.confirmPassword())) {
       return "Passwords do not match.";
+    }
 
     return null;
   }

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/UserService.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/service/UserService.java
@@ -53,13 +53,24 @@ public class UserService {
    * Validates the password update data.
    *
    * @param passwordUpdateDto The password update data to validate.
-   * @return true if the password update data is valid, false otherwise.
+   * @return the error message if the password update data is not valid, null otherwise.
    */
-  public boolean isValidPasswordUpdateDto(PasswordUpdateDto passwordUpdateDto) {
+  public String isValidPasswordUpdateDto(PasswordUpdateDto passwordUpdateDto) {
+    // DTO validation
     Set<ConstraintViolation<PasswordUpdateDto>> violations = validator.validate(
         passwordUpdateDto);
+    if (!violations.isEmpty())
+      return "All fields must be filled.";
 
-    return violations.isEmpty();
+    // Password validation
+    if (UserService.isNotValidPassword(passwordUpdateDto.newPassword()))
+      return "Invalid password.";
+
+    // Check if the two passwords in the DTO are the same
+    if (!passwordUpdateDto.newPassword().equals(passwordUpdateDto.confirmPassword()))
+      return "Passwords do not match.";
+
+    return null;
   }
 
   /**
@@ -245,20 +256,9 @@ public class UserService {
     }
 
     // DTO validation
-    if (!isValidPasswordUpdateDto(passwordUpdateDto)) {
-      response.put("msg", "All fields must be filled.");
-      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
-    }
-
-    // Password validation
-    if (UserService.isNotValidPassword(passwordUpdateDto.newPassword())) {
-      response.put("msg", "Invalid password.");
-      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
-    }
-
-    // Check if the two passwords in the DTO are the same
-    if (!passwordUpdateDto.newPassword().equals(passwordUpdateDto.confirmPassword())) {
-      response.put("msg", "Passwords do not match.");
+    String msg = isValidPasswordUpdateDto(passwordUpdateDto);
+    if (msg != null) {
+      response.put("msg", msg);
       return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/view/AuthViewController.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/view/AuthViewController.java
@@ -28,4 +28,14 @@ public class AuthViewController {
   public String signup() {
     return "auth/sign_up";
   }
+
+  /**
+   * Returns the forgot password view.
+   *
+   * @return the forgot password view
+   */
+  @GetMapping("/forgot-password")
+  public String forgotPassword() {
+    return "auth/forgot_password";
+  }
 }

--- a/qualitag/src/main/java/it/unisannio/studenti/qualitag/view/AuthViewController.java
+++ b/qualitag/src/main/java/it/unisannio/studenti/qualitag/view/AuthViewController.java
@@ -38,4 +38,14 @@ public class AuthViewController {
   public String forgotPassword() {
     return "auth/forgot_password";
   }
+
+  /**
+   * Returns the reset password view.
+   *
+   * @return the reset password view
+   */
+  @GetMapping("/reset-password")
+  public String resetPassword() {
+    return "auth/reset_password";
+  }
 }

--- a/qualitag/src/main/resources/application.properties
+++ b/qualitag/src/main/resources/application.properties
@@ -12,3 +12,6 @@ token.secret.key=48a868a4042f634ac04a117f00a87202131dd7c46c4b32c4acb3edc5e15f451
 
 # JWT expiration is 1 hour
 token.expiration=3600000
+
+# JWT password reset token is 15 minutes
+token.password.expiration=15

--- a/qualitag/src/main/resources/static/css/forgot-password.css
+++ b/qualitag/src/main/resources/static/css/forgot-password.css
@@ -1,0 +1,46 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background-color: #f4f4f4;
+}
+
+.forgot-password-form {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.forgot-password-form label {
+  font-size: 14px;
+  margin-bottom: 8px;
+  display: block;
+}
+
+.forgot-password-form input {
+  width: 100%;
+  padding: 10px;
+  margin-bottom: 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.forgot-password-form button {
+  width: 100%;
+  padding: 10px;
+  background: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+.forgot-password-form button:hover {
+  background: #0056b3;
+}

--- a/qualitag/src/main/resources/static/js/auth/forgot-password.js
+++ b/qualitag/src/main/resources/static/js/auth/forgot-password.js
@@ -1,0 +1,31 @@
+document.getElementById("forgotPasswordForm").addEventListener("submit", function (event) {
+  event.preventDefault(); // Prevent the default form submission
+
+  const email = document.getElementById("email").value;
+
+  // Validate email
+  if (!email) {
+    alert("Please enter a valid email address.");
+    return;
+  }
+
+  // Send a POST request to the server
+  fetch("/api/v1/auth/forgot-password", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ email: email }),
+  })
+  .then((response) => {
+    if (response.ok) {
+      alert("Password reset email sent successfully.");
+    } else {
+      alert("Error sending email. Please try again.");
+    }
+  })
+  .catch((error) => {
+    console.error("Error:", error);
+    alert("An error occurred. Please try again.");
+  });
+});

--- a/qualitag/src/main/resources/static/js/auth/forgot-password.js
+++ b/qualitag/src/main/resources/static/js/auth/forgot-password.js
@@ -1,4 +1,4 @@
-document.getElementById("forgotPasswordForm").addEventListener("submit", function (event) {
+document.getElementById("forgotPasswordForm").addEventListener("submit", async function (event) {
   event.preventDefault(); // Prevent the default form submission
 
   const email = document.getElementById("email").value;
@@ -10,22 +10,24 @@ document.getElementById("forgotPasswordForm").addEventListener("submit", functio
   }
 
   // Send a POST request to the server
-  fetch("/api/v1/auth/forgot-password", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ email: email }),
-  })
-  .then((response) => {
+  try {
+    const response = await fetch("/api/v1/auth/forgot-password", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({email: email}),
+    });
+
+    const responseData = await response.json();
+
     if (response.ok) {
-      alert("Password reset email sent successfully.");
+      alert(responseData.msg || "Password reset email sent successfully.");
+      window.location.href = "/"; // Redirect to the home page
     } else {
       alert("Error sending email. Please try again.");
     }
-  })
-  .catch((error) => {
-    console.error("Error:", error);
-    alert("An error occurred. Please try again.");
-  });
+  } catch (error) {
+    alert('An error occurred: ' + error.message);
+  }
 });

--- a/qualitag/src/main/resources/static/js/auth/reset-password-script.js
+++ b/qualitag/src/main/resources/static/js/auth/reset-password-script.js
@@ -1,0 +1,31 @@
+document.getElementById('resetPasswordForm').addEventListener('submit', async function (event) {
+  event.preventDefault();
+
+  // Extract token from URL query parameter
+  const urlParams = new URLSearchParams(window.location.search);
+  const token = urlParams.get("token");
+
+  const formData = new FormData(event.target);
+  const data = Object.fromEntries(formData.entries());
+
+  try {
+    const response = await fetch('/api/v1/auth/reset-password?token=' + encodeURIComponent(token), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data)
+    });
+
+    const responseData = await response.json();
+
+    if (response.ok) {
+      alert(responseData.msg || 'Password updated successfully.');
+      window.location.href = '/';
+    } else {
+      alert('Update failed: ' + (responseData.msg || 'Unknown error'));
+    }
+  } catch (error) {
+    alert('An error occurred: ' + error.message);
+  }
+});

--- a/qualitag/src/main/resources/templates/auth/forgot_password.html
+++ b/qualitag/src/main/resources/templates/auth/forgot_password.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Forgot Password</title>
+  <link rel="stylesheet" href="/css/forgot-password.css">
+</head>
+<body>
+
+<div class="forgot-password-form">
+  <form id="forgotPasswordForm">
+    <label for="email">Enter your email address:</label>
+    <input type="email" id="email" name="email" placeholder="Email address" required>
+    <button type="submit">Send Email</button>
+  </form>
+</div>
+
+<script src="/js/auth/forgot-password.js"></script>
+</body>
+</html>

--- a/qualitag/src/main/resources/templates/auth/reset_password.html
+++ b/qualitag/src/main/resources/templates/auth/reset_password.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reset password</title>
+</head>
+<body>
+<h2>Reset Password</h2>
+<form id="resetPasswordForm">
+  <label for="newPassword">New password:</label>
+  <input type="password" id="newPassword" name="newPassword" required><br><br>
+
+  <label for="confirmPassword">Confirm new password:</label>
+  <input type="password" id="confirmPassword" name="confirmPassword" required><br><br>
+
+  <button type="submit">Reset</button>
+</form>
+
+<!-- Handle form -->
+<script src="/js/auth/reset-password-script.js"></script>
+</body>
+</html>

--- a/qualitag/src/main/resources/templates/auth/sign_in.html
+++ b/qualitag/src/main/resources/templates/auth/sign_in.html
@@ -17,6 +17,9 @@
     <button type="submit">Login</button>
   </form>
 
+  <p>Don't have an account? <a href="/sign-up">Sign Up</a></p>
+  <p><a href="/forgot-password">Forgot password?</a></p>
+
 <script src="/js/auth/sign-in-script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
New adds and changes:
- Added email service based on Gmail API. Useful to send notifications to the user, registration validation, reset password and more.
- Added reset password feature. If a registered user forgot the password to access to the platform can click on "Forgot password" and be brought to a page where the user can insert the email used to register. An email will then be sent to said email containing a link that can be used for password reset. The link will be valid for 15 minutes.
- More minor fixes